### PR TITLE
Add deprecation notices to Docs/ and update README links

### DIFF
--- a/Docs/1_Authentication.md
+++ b/Docs/1_Authentication.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/flutter](https://www.courier.com/docs/sdk-libraries/flutter/). The content below may be outdated.
+
 # Authentication
 
 Manages user credentials between app sessions.

--- a/Docs/2_Inbox.md
+++ b/Docs/2_Inbox.md
@@ -1,5 +1,7 @@
 <img width="1040" alt="banner-flutter-inbox" src="https://github.com/trycourier/courier-flutter/assets/6370613/57eb1876-6cf3-4ecd-a9ff-134c36c45678">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/flutter](https://www.courier.com/docs/sdk-libraries/flutter/). The content below may be outdated.
+
 &emsp;
 
 # Courier Inbox

--- a/Docs/3_PushNotifications.md
+++ b/Docs/3_PushNotifications.md
@@ -1,5 +1,7 @@
 <img width="1040" alt="banner-flutter-push" src="https://github.com/trycourier/courier-flutter/assets/6370613/45e4a58b-2bad-49fb-850d-244be3ffd0d7">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/flutter](https://www.courier.com/docs/sdk-libraries/flutter/). The content below may be outdated.
+
 &emsp;
 
 # Push Notifications

--- a/Docs/4_Preferences.md
+++ b/Docs/4_Preferences.md
@@ -1,5 +1,7 @@
 <img width="1040" alt="banner-flutter-preferences" src="https://github.com/trycourier/courier-flutter/assets/6370613/29da0de2-bd74-4ed8-9245-ebbe1d74ff19">
 
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/flutter](https://www.courier.com/docs/sdk-libraries/flutter/). The content below may be outdated.
+
 # Courier Preferences
 
 Allow users to update which types of notifications they would like to receive.

--- a/Docs/5_Client.md
+++ b/Docs/5_Client.md
@@ -1,3 +1,5 @@
+> **Note**: These docs have moved to [courier.com/docs/sdk-libraries/flutter](https://www.courier.com/docs/sdk-libraries/flutter/). The content below may be outdated.
+
 # `CourierClient`
 
 Base layer Courier API wrapper.

--- a/README.md
+++ b/README.md
@@ -115,12 +115,12 @@ These are all the available features of the SDK.
                 1
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/1_Authentication.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/flutter/#authentication">
                     <code>Authentication</code>
                 </a>
             </td>
             <td align="left">
-                Manages user credentials between app sessions. Required if you would like to use <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/2_Inbox.md"><code>Inbox</code></a>, <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/3_PushNotifications.md"><code>Push Notifications</code></a> and <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/4_Preferences.md"><code>Preferences</code></a>.
+                Manages user credentials between app sessions. Required if you would like to use <a href="https://www.courier.com/docs/sdk-libraries/flutter/#inbox"><code>Inbox</code></a>, <a href="https://www.courier.com/docs/sdk-libraries/flutter/#push-notifications"><code>Push Notifications</code></a> and <a href="https://www.courier.com/docs/sdk-libraries/flutter/#preferences"><code>Preferences</code></a>.
             </td>
         </tr>
         <tr width="600px">
@@ -128,7 +128,7 @@ These are all the available features of the SDK.
                 2
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/2_Inbox.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/flutter/#inbox">
                     <code>Inbox</code>
                 </a>
             </td>
@@ -141,7 +141,7 @@ These are all the available features of the SDK.
                 3
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/3_PushNotifications.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/flutter/#push-notifications">
                     <code>Push Notifications</code>
                 </a>
             </td>
@@ -154,7 +154,7 @@ These are all the available features of the SDK.
                 4
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/4_Preferences.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/flutter/#preferences">
                     <code>Preferences</code>
                 </a>
             </td>
@@ -167,7 +167,7 @@ These are all the available features of the SDK.
                 5
             </td>
             <td align="left">
-                <a href="https://github.com/trycourier/courier-flutter/blob/master/Docs/5_Client.md">
+                <a href="https://www.courier.com/docs/sdk-libraries/flutter/#courierclient">
                     <code>CourierClient</code>
                 </a>
             </td>


### PR DESCRIPTION
## Summary

- Adds deprecation notices to all 5 files in `Docs/` pointing to the canonical Mintlify docs at courier.com/docs/sdk-libraries/flutter/
- Updates the README "Getting Started" feature table to link to Mintlify instead of the GitHub Docs/ files