### PR TITLE
SUP-604 Widen intl dependency to support Flutter 3.32+

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -8,7 +8,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+23
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,14 +4,14 @@ version: 4.1.8
 homepage: https://courier.com
 
 environment:
-  sdk: '>=2.18.1 <3.0.0'
+  sdk: '>=3.3.0 <4.0.0'
   flutter: ">=3.13.6"
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_svg: ^2.0.9
-  intl: ^0.19.0
+  intl: '>=0.19.0 <1.0.0'
   package_info_plus: ^8.0.2
   plugin_platform_interface: ^2.0.2
   url_launcher: ^6.2.3


### PR DESCRIPTION
## Summary
- Widen `intl` constraint from `^0.19.0` to `>=0.19.0 <1.0.0` to resolve version conflict with `flutter_localizations` pinning `intl 0.20.2` on Flutter 3.32+
- Update Dart SDK constraint from `>=2.18.1 <3.0.0` to `>=3.3.0 <4.0.0` to match actual Flutter SDK requirements
- Apply same Dart SDK fix to example app pubspec

## Testing
- Reproduced the error locally on Flutter 3.38.1 / Dart 3.10.0 with `courier_flutter ^4.1.8` + `flutter_localizations`; confirmed `flutter pub get` fails
- Verified `dependency_overrides: { intl: ^0.20.2 }` resolves cleanly, confirming no API incompatibility
- Only `DateFormat` from `intl` is used (in `lib/models/inbox_message.dart`); stable across 0.19.x and 0.20.x

Fixes #27

[SUP-604](https://linear.app/trycourier/issue/SUP-604/bug-courier-flutter-incompatible-with-flutter-332-due-to-outdated-intl)