### PR TITLE
Bump courier-android to 6.0.0 and remove bundled Firebase dependency

### DIFF
--- a/Docs/3_PushNotifications.md
+++ b/Docs/3_PushNotifications.md
@@ -294,8 +294,8 @@ plugins {
 }
 
 dependencies {
-    implementation(platform("com.google.firebase:firebase-bom:32.2.3"))
-    implementation("com.google.firebase:firebase-messaging")
+    implementation platform("com.google.firebase:firebase-bom:34.13.0")
+    implementation "com.google.firebase:firebase-messaging"
 }
 ```
 

--- a/Docs/3_PushNotifications.md
+++ b/Docs/3_PushNotifications.md
@@ -347,6 +347,7 @@ class YourNotificationService : FirebaseMessagingService() {
             android.R.drawable.ic_dialog_info,
             "Notification Service"
         )
+        
     }
 
     override fun onNewToken(token: String) {

--- a/Docs/3_PushNotifications.md
+++ b/Docs/3_PushNotifications.md
@@ -284,47 +284,82 @@ allprojects {
 }
 ```
 
-3. Update your `app/build.gradle` to support the min and compile SDKs
-    - `minSdkVersion 21`
-    - `compileSdkVersion 33`
-4. Run Gradle sync
-5. Change your `MainActivity` to extend the `CourierFlutterActivity` (or `CourierFlutterFragmentActivity` if you're using a `FragmentActivity`)
+3. Add Firebase Messaging to your `app/build.gradle`
+    - The Courier SDK no longer bundles Firebase — your app must add it explicitly
+
+```gradle
+plugins {
+    // ...
+    id "com.google.gms.google-services"
+}
+
+dependencies {
+    implementation(platform("com.google.firebase:firebase-bom:32.2.3"))
+    implementation("com.google.firebase:firebase-messaging")
+}
+```
+
+4. Add your `google-services.json` file to `android/app/`
+    - Download this from the [Firebase Console](https://console.firebase.google.com/) for your project
+
+5. Update your `app/build.gradle` to support the min and compile SDKs
+    - `minSdkVersion 24`
+    - `compileSdkVersion 34`
+6. Run Gradle sync
+7. Change your `MainActivity` to extend the `CourierFlutterActivity` (or `CourierFlutterFragmentActivity` if you're using a `FragmentActivity`)
     - This allows Courier to handle when push notifications are delivered and clicked
-6. Setup a new Notification Service by creating a new file and pasting the code below in it
+8. Setup a new Notification Service by creating a new file and pasting the code below in it
     - This allows you to present a notification to your user when a new notification arrives
 
 ```kotlin
-import android.annotation.SuppressLint
-import com.courier.android.notifications.presentNotification
-import com.courier.android.service.CourierService
+import com.courier.android.Courier
+import com.courier.android.notifications.CourierPushNotificationIntent
+import com.courier.android.notifications.RemoteMessageExtensionsKt
+import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 
-// This is safe. `CourierService` will automatically handle token refreshes.
-@SuppressLint("MissingFirebaseInstanceTokenRefresh")
-class YourNotificationService: CourierService() {
+class YourNotificationService : FirebaseMessagingService() {
 
-    override fun showNotification(message: RemoteMessage) {
-        super.showNotification(message)
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
 
-        // TODO: This is where you will customize the notification that is shown to your users
-        // The function below is used to get started quickly.
-        // You likely do not want to use `message.presentNotification(...)`
-        // For Flutter, you likely do not want to change the handlingClass
-        // More information on how to customize an Android notification here:
-        // https://developer.android.com/develop/ui/views/notifications/build-notification
+        // Notify the Courier SDK that a push was delivered
+        Courier.onMessageReceived(message.data)
 
-        message.presentNotification(
-            context = this,
-            handlingClass = MainActivity::class.java,
-            icon = android.R.drawable.ic_dialog_info
+        // Create the PendingIntent that runs when the user taps the notification
+        val notificationIntent = CourierPushNotificationIntent(
+            this,
+            0,
+            MainActivity::class.java,
+            message
         )
 
+        val title = message.data["title"] ?: message.notification?.title
+        val body = message.data["body"] ?: message.notification?.body
+
+        // Show the notification to the user
+        // More information on how to customize an Android notification here:
+        // https://developer.android.com/develop/ui/views/notifications/build-notification
+        RemoteMessageExtensionsKt.presentNotification(
+            notificationIntent,
+            title,
+            body,
+            android.R.drawable.ic_dialog_info,
+            "Notification Service"
+        )
+    }
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+
+        // Register/refresh this device's FCM token with Courier
+        Courier.onNewToken(token)
     }
 
 }
 ```
 
-7. Add the Notification Service entry in your `AndroidManifest.xml` file
+9. Add the Notification Service entry in your `AndroidManifest.xml` file
 
 ```xml
 <manifest>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,6 +20,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 
@@ -53,6 +54,10 @@ android {
 
 dependencies {
     implementation 'com.google.code.gson:gson:2.11.0'
-    api 'com.github.trycourier:courier-android:5.3.0'
-    api 'com.google.firebase:firebase-messaging-ktx:24.1.0'
+
+    // Courier Core SDK
+    api 'com.github.trycourier:courier-android:6.0.0'
+
+    // Firebase Messaging (needed to resolve RemoteMessage from Courier SDK APIs)
+    compileOnly 'com.google.firebase:firebase-messaging:23.4.1'
 }

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterActivity.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterActivity.kt
@@ -20,7 +20,7 @@ open class CourierFlutterActivity : FlutterActivity() {
         super.onCreate(savedInstanceState)
 
         // Setup and run the agent
-        Courier.agent = CourierAgent.FlutterAndroid(version = "4.3.2")
+        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.0")
         Courier.initialize(context)
 
         // Handle system events

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterFragmentActivity.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterFragmentActivity.kt
@@ -20,7 +20,7 @@ open class CourierFlutterFragmentActivity : FlutterFragmentActivity() {
         super.onCreate(savedInstanceState)
 
         // Setup and run the agent
-        Courier.agent = CourierAgent.FlutterAndroid(version = "4.3.2")
+        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.0")
         Courier.initialize(this)
 
         // Handle system events

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterPushNotificationListener.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterPushNotificationListener.kt
@@ -1,9 +1,7 @@
 package com.courier.courier_flutter
 
-import com.google.firebase.messaging.RemoteMessage
-
 interface CourierFlutterPushNotificationListener {
-    fun postPushNotificationDelivered(message: RemoteMessage)
-    fun postPushNotificationClicked(message: RemoteMessage)
+    fun postPushNotificationDelivered(data: Map<String, String>)
+    fun postPushNotificationClicked(data: Map<String, String>)
 }
 

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierPlugin.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierPlugin.kt
@@ -13,7 +13,7 @@ internal class CourierPlugin : FlutterPlugin {
     }
 
     init {
-        Courier.agent = CourierAgent.FlutterAndroid(version = "4.3.2")
+        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.0")
     }
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierSystemEventHandler.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierSystemEventHandler.kt
@@ -3,9 +3,7 @@ package com.courier.courier_flutter
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
-import android.util.Log
 import com.courier.android.Courier
-import com.courier.android.models.CourierTrackingEvent.CLICKED
 import com.courier.android.models.CourierTrackingEvent.DELIVERED
 import com.courier.android.modules.isPushPermissionGranted
 import com.courier.android.modules.requestNotificationPermission
@@ -17,6 +15,7 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
 
     private var systemChannel: MethodChannel? = null
     private var eventsChannel: MethodChannel? = null
+    private var lastClickedPushNotification: Map<String, Any?>? = null
 
     fun configure(flutterEngine: FlutterEngine, activity: Activity) {
 
@@ -45,8 +44,9 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
 
                 "notifications.get_clicked_notification" -> {
 
-                    activity.intent.getAndTrackPushData()?.let { data ->
-                        postPushNotificationClicked(data)
+                    lastClickedPushNotification?.let { payload ->
+                        eventsChannel?.invokeMethod("push.clicked", payload)
+                        lastClickedPushNotification = null
                     }
 
                     result.success(null)
@@ -73,9 +73,8 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
 
         Courier.onPushNotificationEvent { event ->
             when (event.trackingEvent) {
-                CLICKED -> postPushNotificationClicked(event.data)
                 DELIVERED -> postPushNotificationDelivered(event.data)
-                else -> Log.w("CourierSystemEventHandler", "Unknown tracking event: ${event.trackingEvent}")
+                else -> {}
             }
         }
 
@@ -115,7 +114,9 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
     }
 
     override fun postPushNotificationClicked(data: Map<String, String>) {
-        eventsChannel?.invokeMethod("push.clicked", buildPushPayload(data))
+        val payload = buildPushPayload(data)
+        lastClickedPushNotification = payload
+        eventsChannel?.invokeMethod("push.clicked", payload)
     }
 
 }

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierSystemEventHandler.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierSystemEventHandler.kt
@@ -3,14 +3,13 @@ package com.courier.courier_flutter
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import com.courier.android.Courier
-import com.courier.android.models.CourierTrackingEvent
+import com.courier.android.models.CourierTrackingEvent.CLICKED
+import com.courier.android.models.CourierTrackingEvent.DELIVERED
 import com.courier.android.modules.isPushPermissionGranted
 import com.courier.android.modules.requestNotificationPermission
-import com.courier.android.utils.onPushNotificationEvent
-import com.courier.android.utils.pushNotification
 import com.courier.android.utils.trackPushNotificationClick
-import com.google.firebase.messaging.RemoteMessage
 import io.flutter.embedding.engine.FlutterEngine
 import io.flutter.plugin.common.MethodChannel
 
@@ -21,13 +20,11 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
 
     fun configure(flutterEngine: FlutterEngine, activity: Activity) {
 
-        // Create the method channel
         val messenger = flutterEngine.dartExecutor.binaryMessenger
 
         systemChannel = CourierFlutterChannel.SYSTEM.getChannel(messenger)
         eventsChannel = CourierFlutterChannel.EVENTS.getChannel(messenger)
 
-        // Handle the calls
         systemChannel?.setMethodCallHandler { call, result ->
 
             when (call.method) {
@@ -48,8 +45,8 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
 
                 "notifications.get_clicked_notification" -> {
 
-                    activity.intent.getAndTrackRemoteMessage()?.let { message ->
-                        postPushNotificationClicked(message)
+                    activity.intent.getAndTrackPushData()?.let { data ->
+                        postPushNotificationClicked(data)
                     }
 
                     result.success(null)
@@ -70,16 +67,15 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
 
     fun attach(context: Context, intent: Intent) {
 
-        // Initialize the SDK
         Courier.initialize(context)
 
-        // See if there is a pending click event
         checkIntentForPushNotificationClick(intent)
 
-        // Handle delivered messages on the main thread
-        Courier.shared.onPushNotificationEvent { event ->
-            if (event.trackingEvent == CourierTrackingEvent.DELIVERED) {
-                postPushNotificationDelivered(event.remoteMessage)
+        Courier.onPushNotificationEvent { event ->
+            when (event.trackingEvent) {
+                CLICKED -> postPushNotificationClicked(event.data)
+                DELIVERED -> postPushNotificationDelivered(event.data)
+                else -> Log.w("CourierSystemEventHandler", "Unknown tracking event: ${event.trackingEvent}")
             }
         }
 
@@ -87,7 +83,7 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
 
     private fun checkIntentForPushNotificationClick(intent: Intent?) {
         intent?.trackPushNotificationClick { message ->
-            postPushNotificationClicked(message)
+            postPushNotificationClicked(message.data)
         }
     }
 
@@ -99,12 +95,27 @@ internal class CourierSystemEventHandler : CourierFlutterPushNotificationListene
         eventsChannel?.setMethodCallHandler(null)
     }
 
-    override fun postPushNotificationDelivered(message: RemoteMessage) {
-        eventsChannel?.invokeMethod("push.delivered", message.pushNotification)
+    private fun buildPushPayload(data: Map<String, String>): Map<String, Any?> {
+        val rawData = data.toMutableMap()
+        val payload = mutableMapOf<String, Any?>()
+        val baseKeys = listOf("title", "subtitle", "body", "badge", "sound")
+        baseKeys.forEach { key ->
+            payload[key] = data[key]
+            rawData.remove(key)
+        }
+        for ((key, value) in rawData) {
+            payload[key] = value
+        }
+        payload["raw"] = data
+        return payload
     }
 
-    override fun postPushNotificationClicked(message: RemoteMessage) {
-        eventsChannel?.invokeMethod("push.clicked", message.pushNotification)
+    override fun postPushNotificationDelivered(data: Map<String, String>) {
+        eventsChannel?.invokeMethod("push.delivered", buildPushPayload(data))
+    }
+
+    override fun postPushNotificationClicked(data: Map<String, String>) {
+        eventsChannel?.invokeMethod("push.clicked", buildPushPayload(data))
     }
 
 }

--- a/android/src/main/kotlin/com/courier/courier_flutter/SharedMethodHandler.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/SharedMethodHandler.kt
@@ -10,7 +10,6 @@ import com.courier.android.modules.addInboxListener
 import com.courier.android.modules.archiveMessage
 import com.courier.android.modules.archivedMessages
 import com.courier.android.modules.clickMessage
-import com.courier.android.modules.fcmToken
 import com.courier.android.modules.feedMessages
 import com.courier.android.modules.fetchNextInboxPage
 import com.courier.android.modules.getToken
@@ -177,7 +176,7 @@ internal class SharedMethodHandler(channel: CourierFlutterChannel, private val b
 
                 "tokens.get_fcm_token" -> {
 
-                    val fcmToken = Courier.shared.fcmToken
+                    val fcmToken = Courier.shared.getToken("firebase-fcm")
 
                     result.success(fcmToken)
 

--- a/android/src/main/kotlin/com/courier/courier_flutter/Utils.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/Utils.kt
@@ -4,22 +4,19 @@ import android.content.Intent
 import com.courier.android.client.CourierClient
 import com.courier.android.models.CourierDevice
 import com.courier.android.utils.trackPushNotificationClick
-import com.google.firebase.messaging.RemoteMessage
 import com.google.gson.GsonBuilder
 
-// Remote Message
+// Push Data
 
-internal fun Intent.getAndTrackRemoteMessage(): RemoteMessage? {
+internal fun Intent.getAndTrackPushData(): Map<String, String>? {
 
-    var clickedMessage: RemoteMessage? = null
+    var clickedData: Map<String, String>? = null
 
-    // Try and track the clicked message
-    // Will return a message if the message was able to be tracked
     trackPushNotificationClick { message ->
-        clickedMessage = message
+        clickedData = message.data
     }
 
-    return clickedMessage
+    return clickedData
 
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -108,3 +108,10 @@ android {
 flutter {
     source '../..'
 }
+
+// Firebase Messaging is needed at the app level for the notification service.
+// The Courier SDK no longer bundles it — apps must add it explicitly.
+dependencies {
+    implementation platform("com.google.firebase:firebase-bom:32.2.3")
+    implementation "com.google.firebase:firebase-messaging"
+}

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -112,6 +112,6 @@ flutter {
 // Firebase Messaging is needed at the app level for the notification service.
 // The Courier SDK no longer bundles it — apps must add it explicitly.
 dependencies {
-    implementation platform("com.google.firebase:firebase-bom:32.2.3")
+    implementation platform("com.google.firebase:firebase-bom:34.13.0")
     implementation "com.google.firebase:firebase-messaging"
 }

--- a/example/android/app/src/main/kotlin/com/courier/courier_flutter/ExampleService.kt
+++ b/example/android/app/src/main/kotlin/com/courier/courier_flutter/ExampleService.kt
@@ -32,6 +32,7 @@ class ExampleService : FirebaseMessagingService() {
             title = message.data["title"] ?: message.notification?.title,
             body = message.data["body"] ?: message.notification?.body,
         )
+
     }
 
     override fun onNewToken(token: String) {

--- a/example/android/app/src/main/kotlin/com/courier/courier_flutter/ExampleService.kt
+++ b/example/android/app/src/main/kotlin/com/courier/courier_flutter/ExampleService.kt
@@ -1,31 +1,45 @@
 package com.courier.courier_flutter
 
-import android.annotation.SuppressLint
+import androidx.annotation.NonNull
+import com.courier.android.Courier
+import com.courier.android.notifications.CourierPushNotificationIntent
 import com.courier.android.notifications.presentNotification
-import com.courier.android.service.CourierService
+import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 
-// Warning is suppressed
-// You do not need to worry about this warning
-// The CourierService will handle the function automatically
-@SuppressLint("MissingFirebaseInstanceTokenRefresh")
-class ExampleService: CourierService() {
+class ExampleService : FirebaseMessagingService() {
 
-    override fun showNotification(message: RemoteMessage) {
-        super.showNotification(message)
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
 
-        // TODO: This is where you will customize the notification that is shown to your users
-        // The function below is used to get started quickly.
-        // You likely do not want to use `message.presentNotification(...)`
-        // Make sure you point the handling class back to MainActivity
-        // For details on how to customize an Android notification, check here:
-        // https://developer.android.com/develop/ui/views/notifications/build-notification
+        // Notify the Courier SDK that a push was delivered
+        Courier.onMessageReceived(message.data)
 
-        message.presentNotification(
+        // Create the PendingIntent that runs when the user taps the notification
+        // This intent targets your Activity and carries the original message payload
+        // TODO: Remove this if you'd like. This is mostly useful for demo purposes.
+        val notificationIntent = CourierPushNotificationIntent(
             context = this,
-            handlingClass = MainActivity::class.java
+            target = MainActivity::class.java,
+            payload = message
         )
 
+        // Show the notification to the user.
+        // Prefer data-only FCM so this service runs even in background/killed state.
+        // Fall back to notification fields if data keys are missing.
+        // TODO: Remove this if you'd like. This is mostly useful for demo purposes.
+        notificationIntent.presentNotification(
+            title = message.data["title"] ?: message.notification?.title,
+            body = message.data["body"] ?: message.notification?.body,
+        )
+    }
+
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+
+        // Register/refresh this device's FCM token with Courier.
+        // The SDK caches and updates the token automatically and links it to the current user.
+        Courier.onNewToken(token)
     }
 
 }

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -63,7 +63,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.3.1"
+    version: "5.0.0"
   crypto:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ description: Demonstrates how to use the courier_flutter plugin.
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+28
+version: 1.0.0+29
 
 environment:
   sdk: '>=3.3.0 <4.0.0'

--- a/ios/Classes/CourierFlutterDelegate.swift
+++ b/ios/Classes/CourierFlutterDelegate.swift
@@ -41,7 +41,7 @@ open class CourierFlutterDelegate: FlutterAppDelegate {
         super.init()
         
         // Set the api agent version
-        Courier.agent = CourierAgent.flutterIOS("4.3.2")
+        Courier.agent = CourierAgent.flutterIOS("5.0.0")
         
         // Handle notification registration
         app.registerForRemoteNotifications()

--- a/ios/Classes/CourierFlutterMethodHandler.swift
+++ b/ios/Classes/CourierFlutterMethodHandler.swift
@@ -14,7 +14,7 @@ public class CourierFlutterMethodHandler: NSObject {
         
         // Set the flutter ios user agent
         // This ensures all the requests are tagged with this agent
-        Courier.agent = CourierAgent.flutterIOS("4.3.2")
+        Courier.agent = CourierAgent.flutterIOS("5.0.0")
         
     }
     

--- a/ios/courier_flutter.podspec
+++ b/ios/courier_flutter.podspec
@@ -16,7 +16,7 @@ Inbox, Push Notification & Preferences for Flutter by Courier
   s.source           = { :path => '.' }
   s.source_files = 'Classes/**/*'
   s.dependency 'Flutter'
-  s.dependency 'Courier_iOS', '5.8.0'
+  s.dependency 'Courier_iOS', '5.8.1'
   s.platform = :ios, '15.0'
 
   # Flutter.framework does not contain a i386 slice.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: courier_flutter
 description: Inbox, Push Notifications and Preferences for Flutter
-version: 4.3.2
+version: 5.0.0
 homepage: https://courier.com
 
 environment:


### PR DESCRIPTION
## Summary

- Bumps `courier-android` from 5.3.0 to 6.0.0, which removes Firebase as a transitive dependency
- Changes Firebase Messaging from `api` to `compileOnly` in the plugin, adds JitPack repo
- Migrates push event handling from `RemoteMessage` to data maps (`event.data`)
- Replaces `Courier.shared.fcmToken` with `Courier.shared.getToken("firebase-fcm")`
- Migrates `ExampleService` from the removed `CourierService` to `FirebaseMessagingService` with `Courier.onMessageReceived()` / `Courier.onNewToken()`
- Adds explicit `firebase-messaging` dependency to the example app's `build.gradle`
- Updates push notification docs with new Firebase setup steps and `FirebaseMessagingService` pattern
- Bumps `Courier_iOS` from 5.8.0 to 5.8.1

## Test plan

- [x] Build and run the example app on a physical Android device
- [x] Verify push notification delivery triggers `push.delivered` in Dart
- [x] Verify tapping a notification triggers `push.clicked` in Dart
- [x] Verify FCM token sync works on sign-in
- [x] Verify cold-start click tracking works (app killed -> tap notification -> app opens)
- [x] Verify iOS still builds and runs correctly


Made with [Cursor](https://cursor.com)