### PR TITLE
chore: bump SDK version to 5.0.2

### DIFF
--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterActivity.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterActivity.kt
@@ -20,7 +20,7 @@ open class CourierFlutterActivity : FlutterActivity() {
         super.onCreate(savedInstanceState)
 
         // Setup and run the agent
-        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.1")
+        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.2")
         Courier.initialize(context)
 
         // Handle system events

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterFragmentActivity.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierFlutterFragmentActivity.kt
@@ -20,7 +20,7 @@ open class CourierFlutterFragmentActivity : FlutterFragmentActivity() {
         super.onCreate(savedInstanceState)
 
         // Setup and run the agent
-        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.1")
+        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.2")
         Courier.initialize(this)
 
         // Handle system events

--- a/android/src/main/kotlin/com/courier/courier_flutter/CourierPlugin.kt
+++ b/android/src/main/kotlin/com/courier/courier_flutter/CourierPlugin.kt
@@ -13,7 +13,7 @@ internal class CourierPlugin : FlutterPlugin {
     }
 
     init {
-        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.1")
+        Courier.agent = CourierAgent.FlutterAndroid(version = "5.0.2")
     }
 
     override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -5,7 +5,7 @@ description: Demonstrates how to use the courier_flutter plugin.
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 1.0.0+33
+version: 1.0.0+34
 
 environment:
   sdk: '>=3.3.0 <4.0.0'

--- a/ios/Classes/CourierFlutterDelegate.swift
+++ b/ios/Classes/CourierFlutterDelegate.swift
@@ -41,7 +41,7 @@ open class CourierFlutterDelegate: FlutterAppDelegate {
         super.init()
         
         // Set the api agent version
-        Courier.agent = CourierAgent.flutterIOS("5.0.1")
+        Courier.agent = CourierAgent.flutterIOS("5.0.2")
         
         // Handle notification registration
         app.registerForRemoteNotifications()

--- a/ios/Classes/CourierFlutterMethodHandler.swift
+++ b/ios/Classes/CourierFlutterMethodHandler.swift
@@ -14,7 +14,7 @@ public class CourierFlutterMethodHandler: NSObject {
         
         // Set the flutter ios user agent
         // This ensures all the requests are tagged with this agent
-        Courier.agent = CourierAgent.flutterIOS("5.0.1")
+        Courier.agent = CourierAgent.flutterIOS("5.0.2")
         
     }
     

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: courier_flutter
 description: Inbox, Push Notifications and Preferences for Flutter
-version: 5.0.1
+version: 5.0.2
 homepage: https://courier.com
 
 environment:


### PR DESCRIPTION
## Summary
- Bump Courier Flutter SDK version from 5.0.1 to 5.0.2
- Update `pubspec.yaml`, iOS/Android agent strings, and example app build number

## Test plan
- [ ] CI passes
- [ ] Example app builds successfully


Made with [Cursor](https://cursor.com)