### PR TITLE
chore: update copyright year to 2026 and bump to 5.0.3

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Courier
+Copyright (c) 2026 Courier
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: courier_flutter
 description: Inbox, Push Notifications and Preferences for Flutter
-version: 5.0.2
+version: 5.0.3
 homepage: https://courier.com
 
 environment:


### PR DESCRIPTION
## Summary
- Updates copyright year in LICENSE from 2022 → 2026
- Bumps version from 5.0.2 → 5.0.3

## Test plan
- [ ] Verify LICENSE displays correctly on pub.dev after publish

Made with [Cursor](https://cursor.com)